### PR TITLE
Changing the status bar to reflect the review status before distributing

### DIFF
--- a/docs/101-Glossaryofacronyms.md
+++ b/docs/101-Glossaryofacronyms.md
@@ -1,8 +1,8 @@
 ---
 title: Glossary of Acronyms
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 | Term    |  Definition                                        |

--- a/docs/api-concepts/01-Introduction.md
+++ b/docs/api-concepts/01-Introduction.md
@@ -2,8 +2,8 @@
 title: Introduction
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Welcome to our API Design and Development Standards. The intent of this section is to provide you with the high level introductory concepts that will be used throughout these standards.

--- a/docs/api-concepts/02-Why use standards.md
+++ b/docs/api-concepts/02-Why use standards.md
@@ -2,8 +2,8 @@
 title: Why use standards?
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 When there are standards, it means that people in the industry/sector have got together and thought about the question: “What is the best way to do this?”.

--- a/docs/api-concepts/03-Value of API standards.md
+++ b/docs/api-concepts/03-Value of API standards.md
@@ -2,8 +2,8 @@
 title: Value of API standards
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 The full potential of the technology is reached when everyone is aligned with the standards, therefore everyone must work together on standards.

--- a/docs/api-concepts/04-Partners.md
+++ b/docs/api-concepts/04-Partners.md
@@ -2,8 +2,8 @@
 title: Partners
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Standards

--- a/docs/api-concepts/ComponentDefinitions.md
+++ b/docs/api-concepts/ComponentDefinitions.md
@@ -2,8 +2,8 @@
 title: Standards Component Definitions
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 This section provides a list of common API standards components and their associated definitions.

--- a/docs/api-development/01-Introduction.md
+++ b/docs/api-development/01-Introduction.md
@@ -2,8 +2,8 @@
 title: Introduction
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Digital health can transform the outcomes and experience of health consumers if information is shared seamlessly. When digital products, services and information systems work together in this way, we call it being interoperable.

--- a/docs/api-development/02-API Design.md
+++ b/docs/api-development/02-API Design.md
@@ -2,8 +2,8 @@
 title: "API Design"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 This section looks at API design and offers the standards required to support [health sector organisations](../api-concepts/ComponentDefinitions#health-sector-organisations) in designing, developing and governing APIs. The intended audience for this section of the document is **_technical_** for example [API developers](../api-concepts/ComponentDefinitions#api-developers), or [API designers](../api-concepts/ComponentDefinitions#api-designers).

--- a/docs/api-development/03-API Artefacts.md
+++ b/docs/api-development/03-API Artefacts.md
@@ -2,8 +2,8 @@
 title: API Artefacts
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 > All of the artefacts listed below **MUST** be maintained in a system that is able to support change tracking.

--- a/docs/api-development/05-Architectural Patterns.md
+++ b/docs/api-development/05-Architectural Patterns.md
@@ -2,8 +2,8 @@
 title: "API Architectural Patterns"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 The table below identifies some architectural and deployment patterns

--- a/docs/api-development/06-ConsumptionPatterns.md
+++ b/docs/api-development/06-ConsumptionPatterns.md
@@ -2,8 +2,8 @@
 title: API Consumption Patterns
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Direct

--- a/docs/api-development/07-HTTPVerbs.md
+++ b/docs/api-development/07-HTTPVerbs.md
@@ -2,8 +2,8 @@
 title: "HTTP Verbs"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Access to REST APIs **MUST** be via the standard HTTP verbs: GET, PUT, POST, DELETE in line with the [<u>W3C Standard</u>](https://www.w3.org/2001/tag/doc/whenToUseGet.html) namely:

--- a/docs/api-development/08-URIs.md
+++ b/docs/api-development/08-URIs.md
@@ -2,8 +2,8 @@
 title: "Uniform Resource Identifiers (URI)"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## URI Construction

--- a/docs/api-development/09-Headers.md
+++ b/docs/api-development/09-Headers.md
@@ -2,8 +2,8 @@
 title: "HTTP Headers"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Request Headers

--- a/docs/api-development/10-Content.md
+++ b/docs/api-development/10-Content.md
@@ -2,8 +2,8 @@
 title: "Content"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Returned Content

--- a/docs/api-development/11-State.md
+++ b/docs/api-development/11-State.md
@@ -2,8 +2,8 @@
 title: "API State"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Consideration of state

--- a/docs/api-development/12-Transactions.md
+++ b/docs/api-development/12-Transactions.md
@@ -2,8 +2,8 @@
 title: "Transaction APIs"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Batch Handling & Transactions

--- a/docs/api-development/13-Version Control.md
+++ b/docs/api-development/13-Version Control.md
@@ -2,8 +2,8 @@
 title: "Versioning APIs"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Semantic Versioning

--- a/docs/api-development/14-Search.md
+++ b/docs/api-development/14-Search.md
@@ -2,8 +2,8 @@
 title: "Search APIs"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Search capability is an important component of many REST APIs. Search is usually used to find resources within a [collection](./Content#singletons-vs-collections) that meet the API Consumers requirements.

--- a/docs/api-development/15-Caching.md
+++ b/docs/api-development/15-Caching.md
@@ -2,8 +2,8 @@
 title: "Caching"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Caching enables faster responses from APIs and reduces server load. It

--- a/docs/api-development/16-Error Handling.md
+++ b/docs/api-development/16-Error Handling.md
@@ -2,8 +2,8 @@
 title: "Error Handling"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Error handling is important because API consumers see the API as a black

--- a/docs/api-development/17-Governance.md
+++ b/docs/api-development/17-Governance.md
@@ -2,8 +2,8 @@
 title: "API Governance"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 API governance helps save time and money because it ensures that APIs

--- a/docs/api-development/24-DevelopmentIndustryStandards.md
+++ b/docs/api-development/24-DevelopmentIndustryStandards.md
@@ -2,8 +2,8 @@
 title: API Development Industry Standards
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Standards for Developing APIs

--- a/docs/api-development/25-FurtherReading.md
+++ b/docs/api-development/25-FurtherReading.md
@@ -2,8 +2,8 @@
 title: "Further Reading"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 - [OWASP API Security Project](https://www.owasp.org/index.php/OWASP_API_Security_Project)

--- a/docs/api-security/01-IntroductiontoAPISecurity.md
+++ b/docs/api-security/01-IntroductiontoAPISecurity.md
@@ -2,8 +2,8 @@
 title: Introduction
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Introduction to API Security

--- a/docs/api-security/02-SecurityReferenceArchitecture.md
+++ b/docs/api-security/02-SecurityReferenceArchitecture.md
@@ -2,8 +2,8 @@
 title: Security Reference Architecture
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 This section describes an API Security Reference Architecture and its

--- a/docs/api-security/03-APIAuthentcationandAuthorisationBasics.md
+++ b/docs/api-security/03-APIAuthentcationandAuthorisationBasics.md
@@ -2,8 +2,8 @@
 title: API Authentication and Authorisation Basics
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## API Authentication & Authorisation Basics

--- a/docs/api-security/04-SecurityControls.md
+++ b/docs/api-security/04-SecurityControls.md
@@ -1,8 +1,8 @@
 ---
 title: Security Controls
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Depending on the classification of the information that is presented in the APIs and the Risk Framework applied, different access controls will need to be applied. This section provides a summary of the controls that **SHOULD** be implemented when protecting Health APIs. The five areas that **MUST** be considered are:
@@ -22,18 +22,18 @@ Using the Resource Type definition detailed in FHIR, the controls above will be 
 |Resource Type|Data Type|Classification|
 |---|---|---|
 |Anonymous Read Access|<li>Does not contain any individual data, or business sensitive data</li><li>Contains important information that must be authenticated back to the source publishing them</li>**Examples:**<li>Capability Statement</li><li>Clinical User Definition</li>| PUBLIC|
-|Business Sensitive|<li>Does not contain any individual data</li><li>Contains data that describe business or service sensitive data</li><li>Contains data related to organisation, location, or other group that is not identifiable as individuals</li>**Examples:**<li>Location</li><li>Medication</li>| IN-CONFIDENCE|
-|Individual Sensitive|<li>Does NOT contain Patient data</li><li>Contains individual information about other participants i.e. Practitioners and Practitioner Role.</li> **Examples;**<li>Practitioner</li><li>Practitioner Role</li>| IN-CONFIDENCE|
-|Patient Sensitive|<li>Contain highly sensitive health information</li><li>Closely linked to highly sensitive health information</li>**Examples:**<li>Procedure</li><li>Invoices</li>| SENSITIVE|
+|Business|<li>Does not contain any individual data</li><li>Contains data that describe business or service sensitive data</li><li>Contains data related to organisation, location, or other group that is not identifiable as individuals</li>**Examples:**<li>Location</li><li>Medication</li>| IN-CONFIDENCE|
+|Individual|<li>Does NOT contain Patient data</li><li>Contains individual information about other participants i.e. Practitioners and Practitioner Role.</li> **Examples;**<li>Practitioner</li><li>Practitioner Role</li>| IN-CONFIDENCE|
+|Patient|<li>Contain highly sensitive health information</li><li>Closely linked to highly sensitive health information</li>**Examples:**<li>Procedure</li><li>Invoices</li>| SENSITIVE|
 
 The following controls are recommended by the FHIR specification and **MUST** be implemented by the API provider:
 
 |Resource Type|Control Required|
 |---|---|
 |Anonymous Read Access|<li>No access control based on the user or system requesting are required</li><li>**MUST** use TLS (HTTPS) to provide authentication of the server and integrity protection in transit</li>|
-|Business Sensitive|<li>Client authentication is required to assure that only authorized access is given</li><li>The Client can be a person or a System</li>Client authentication methods **SHOULD** use at least one of:<li>mutual-authenticated-TLS</li><li>APIKey</li><li>App signed JWT</li><li>App OAuth client-id JWT</li><li>Business protected Provider Directory can be used to provide information that can be used for ABAC / RBAC controls</li>|
-|Individual Sensitive|<li>Apply RBAC or ABAC access polices</li>|
-Patient Sensitive|<li>Often requires a declared Purpose Of Use</li><li>Controlled by a Privacy Consent</li><li>Security labels to differentiate various confidentiality levels within this broad group of Patient Sensitive data</li>|
+|Business|<li>Client authentication is required to assure that only authorized access is given</li><li>The Client can be a person or a System</li>Client authentication methods **SHOULD** use at least one of:<li>mutual-authenticated-TLS</li><li>APIKey</li><li>App signed JWT</li><li>App OAuth client-id JWT</li><li>Business protected Provider Directory can be used to provide information that can be used for ABAC / RBAC controls</li>|
+|Individual|<li>Apply RBAC or ABAC access polices</li>|
+Patient|<li>Often requires a declared Purpose Of Use</li><li>Controlled by a Privacy Consent</li><li>Security labels to differentiate various confidentiality levels within this broad group of Patient Sensitive data</li>|
 
 ## Confidentiality and Integrity
 

--- a/docs/api-security/05-BuildingSecureAPIs.md
+++ b/docs/api-security/05-BuildingSecureAPIs.md
@@ -2,8 +2,8 @@
 title: Building Secure APIs
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Design Principles

--- a/docs/api-security/06-CloudAPISecurity.md
+++ b/docs/api-security/06-CloudAPISecurity.md
@@ -2,8 +2,8 @@
 title: Cloud API security
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/api-security/07-MappingStandardsComponentstoAPISecurityFramework.md
+++ b/docs/api-security/07-MappingStandardsComponentstoAPISecurityFramework.md
@@ -1,8 +1,8 @@
 ---
 title: Mapping Standards Components to API Security Framework
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 API Concepts section of this standard define the following components

--- a/docs/api-security/08-SecuringAPIswithOAuth2andOpenIDConnect.md
+++ b/docs/api-security/08-SecuringAPIswithOAuth2andOpenIDConnect.md
@@ -2,8 +2,8 @@
 title: Using OAuth 2 and OpenID Connect to Secure Your API
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 OAuth 2.0 and OpenID Connect are both based on a token-based authorisation framework and are defined and implemented using Grant Flow type patterns. These define the different types of interaction a client application can perform to gain an "access token” and thus access to the protected API.

--- a/docs/api-security/08a- AlternativeOAuth2OIDCGrantFlowExtensions.md
+++ b/docs/api-security/08a- AlternativeOAuth2OIDCGrantFlowExtensions.md
@@ -1,8 +1,8 @@
 ---
 title: Alternative OAuth 2 Grant Flow Extensions and Web Application Patterns
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Assertion Grant Flows

--- a/docs/api-security/09-TokenProtectionandClientAuthentication.md
+++ b/docs/api-security/09-TokenProtectionandClientAuthentication.md
@@ -2,8 +2,8 @@
 title: Client Authentication and Token Protection
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Client Authentication Standards

--- a/docs/api-security/10-LevelofAssurance.md
+++ b/docs/api-security/10-LevelofAssurance.md
@@ -2,8 +2,8 @@
 title: Level of Assurance
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Level of Assurance (LoA) has been defined to support the OpenID Connect API security framework. OpenID Connect introduces the concept of identity claims about the end user. The Level of Assurance claim is required to:

--- a/docs/api-security/11-RiskConsideration.md
+++ b/docs/api-security/11-RiskConsideration.md
@@ -2,8 +2,8 @@
 title: Consideration of Risks
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/api-security/12- PARJARMandSessionManagement.md
+++ b/docs/api-security/12- PARJARMandSessionManagement.md
@@ -1,8 +1,8 @@
 ---
 title: PAR, JARM and Session Management
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Pushed Authorised Request (PAR)

--- a/docs/api-security/13-FHIRSecurity.md
+++ b/docs/api-security/13-FHIRSecurity.md
@@ -1,8 +1,8 @@
 ---
 title: FHIR Security
 ---
-:::warning[In Development]
-This section is in development and is not complete or ready for review.
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/api-security/25-RelatedStandards.md
+++ b/docs/api-security/25-RelatedStandards.md
@@ -2,8 +2,8 @@
 title: "Related Internet and NZ standards"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Current Internet standards (IETF RFC) relating to OAuth 2.0 security

--- a/docs/community/01-introduction/01.1-roles.md
+++ b/docs/community/01-introduction/01.1-roles.md
@@ -1,7 +1,7 @@
 # Community Roles
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Understanding the different roles will help you get quickly oriented to the community.

--- a/docs/community/01-introduction/01.2-documentation.md
+++ b/docs/community/01-introduction/01.2-documentation.md
@@ -1,7 +1,7 @@
 # Community Documentation
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Our community also has documentation - you're reading it now.

--- a/docs/community/01-introduction/01.3-tools.md
+++ b/docs/community/01-introduction/01.3-tools.md
@@ -1,7 +1,7 @@
 # Community Tooling
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Underpinning the community is a set of tools to organise and enable collaboration. You may choose to get familiar with these tools:

--- a/docs/community/01-introduction/01.4-collab-process.md
+++ b/docs/community/01-introduction/01.4-collab-process.md
@@ -1,7 +1,7 @@
 # Collaboration process
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 The following diagram shows how the community can collaborate together to improve the Standards. This is not a traditional process flow with an absolute start and end, but rather the process operates continually and has many points of entry (as shown by the coloured dots near the top of the diagram).

--- a/docs/community/01-introduction/index.md
+++ b/docs/community/01-introduction/index.md
@@ -1,8 +1,8 @@
 ---
 title: Introduction
 ---
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Welcome to the Hira API Standards project community!

--- a/docs/community/02-guidelines/02.1-communicating-effectively.md
+++ b/docs/community/02-guidelines/02.1-communicating-effectively.md
@@ -2,8 +2,8 @@
 title: Communicating Effectively
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Building good community relies on clear communication between  members.  Please consider the following points as you review the Standards and offer your comments and suggestions.

--- a/docs/community/02-guidelines/02.3-sof-charter.md
+++ b/docs/community/02-guidelines/02.3-sof-charter.md
@@ -2,8 +2,8 @@
 title: Standards Oversight Forum Charter
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Section 1. Guiding Principle

--- a/docs/community/03-get-involved/03.1-participating.md
+++ b/docs/community/03-get-involved/03.1-participating.md
@@ -2,8 +2,8 @@
 title: Participating
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 There are all sorts of ways to participate. Here are a few ideas to help you get involved and ensure the community gets the most out of your participation.

--- a/docs/community/04-facilitating.md
+++ b/docs/community/04-facilitating.md
@@ -2,8 +2,8 @@
 title: Facilitating
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 A welcoming community is an investment into the future and reputation of the Hira API Standards. It is important to give contributors a positive experience, and to make it easy for them to keep coming back.

--- a/docs/community/05-metrics.md
+++ b/docs/community/05-metrics.md
@@ -2,8 +2,8 @@
 title: Measuring
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Data, when used wisely, can help the Standards Oversight Forum (SOF) and moderators make better decisions.

--- a/docs/fhir-api-standard/Principles and Guidelines/01-Principles.md
+++ b/docs/fhir-api-standard/Principles and Guidelines/01-Principles.md
@@ -2,8 +2,8 @@
 title: "FHIR API Design Principles"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info
@@ -11,7 +11,7 @@ Ready for review
 For information about how to contribute please see the [collaboration guidelines](/community/Introduction).
 :::
 
-This section contains **recommended** principles (this page) and guidelines (other pages) for all designers and implementers of Aotearoa New Zealand FHIR-based APIs.
+This section contains **RECOMMENDED** principles (this page) and guidelines (other pages) for all designers and implementers of Aotearoa New Zealand FHIR-based APIs.
 
 ### Design principles for FHIR APIs
 

--- a/docs/fhir-api-standard/Principles and Guidelines/02-DataMapping.md
+++ b/docs/fhir-api-standard/Principles and Guidelines/02-DataMapping.md
@@ -4,8 +4,8 @@ title: "Agree Data Mapping"
 
 ## Agree data mapping with business stakeholders before committing FHIR API design
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ### Recommendations

--- a/docs/fhir-api-standard/Principles and Guidelines/03-ExistingIGs.md
+++ b/docs/fhir-api-standard/Principles and Guidelines/03-ExistingIGs.md
@@ -2,8 +2,8 @@
 title: "Existing Implementation Guides"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/Principles and Guidelines/04-FHIRDataModel.md
+++ b/docs/fhir-api-standard/Principles and Guidelines/04-FHIRDataModel.md
@@ -4,8 +4,8 @@ title: "Develop a FHIR data model"
 
 ## Develop a FHIR data model to communicate the data design
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Data models help people understand what information is being collected and managed and how it relates to other data in existing systems/applications.

--- a/docs/fhir-api-standard/Standards/00-Overview.md
+++ b/docs/fhir-api-standard/Standards/00-Overview.md
@@ -2,8 +2,8 @@
 title: "Overview"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info
@@ -35,4 +35,4 @@ There are also Guidelines which provide additional recommendations for designers
 |   ▢   |  -  | Use recognised official Urls in new definitions and terminology                                                         |
 |   ▢   |  -  | Informational content of Implementation Guides                                                                          |
 |   ▢   |  -  | Rules for resource profiling                                                                                            |
-|   ▢   |  -  | Public FHIR API compatibility rules                                                                                      |
+|   ▢   |  -  | Public FHIR API compatibility rules                                                                                     |

--- a/docs/fhir-api-standard/Standards/01-APIDeliverables.md
+++ b/docs/fhir-api-standard/Standards/01-APIDeliverables.md
@@ -2,8 +2,8 @@
 title: "API Deliverables"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## FHIR APIs **MUST** deliver the following items

--- a/docs/fhir-api-standard/Standards/02-Interoperability.md
+++ b/docs/fhir-api-standard/Standards/02-Interoperability.md
@@ -4,8 +4,8 @@ title: "Interoperability"
 
 ## Interoperability of NZ FHIR health implementations
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/Standards/03-NZBase.md
+++ b/docs/fhir-api-standard/Standards/03-NZBase.md
@@ -4,8 +4,8 @@ title: "Use NZ Base"
 
 ## Use NZ Base IG resource profiles and definitions
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/Standards/04-CanonicalUrls.md
+++ b/docs/fhir-api-standard/Standards/04-CanonicalUrls.md
@@ -2,8 +2,8 @@
 title: "Canonical URLs"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/Standards/05-IGInformation.md
+++ b/docs/fhir-api-standard/Standards/05-IGInformation.md
@@ -2,8 +2,8 @@
 title: "Implementation Guide (IG) Readability"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ## Requirements

--- a/docs/fhir-api-standard/Standards/06-ProfilingRules.md
+++ b/docs/fhir-api-standard/Standards/06-ProfilingRules.md
@@ -4,8 +4,8 @@ title: "Resource profiling"
 
 ## Rules for resource profiling
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 ### Requirements

--- a/docs/fhir-api-standard/Standards/07-CompatibilityRules.md
+++ b/docs/fhir-api-standard/Standards/07-CompatibilityRules.md
@@ -4,8 +4,8 @@ title: "Compatibility rules"
 
 ## Compatibility rules for NZ published FHIR APIs
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/Standards/08-Versioning.md
+++ b/docs/fhir-api-standard/Standards/08-Versioning.md
@@ -2,8 +2,8 @@
 title: "Versioning"
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 :::info

--- a/docs/fhir-api-standard/index.md
+++ b/docs/fhir-api-standard/index.md
@@ -3,8 +3,8 @@ title: "Part D: FHIR API Design and Development Standards"
 sidebar_position: 5
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Welcome to our API Design and Development Standards. This section is aimed at Fast Healthcare Interoperability Resources (FHIR) API producers and consumers

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ sidebar_position: 1
 slug: /
 ---
 
-:::tip[Status]
-Ready for review
+:::warning[Status]
+Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
 Learn about how Te Whatu Ora are implementing APIs to their systems and what the benefits are of doing this.


### PR DESCRIPTION
As requested prior to distributing to a wider audience for review the banner for each page has been altered to reflect the review status.
![image](https://github.com/tewhatuora/api-standards/assets/18519309/041cb09c-28a2-48de-8fb1-1317490ab01c)
