### PR TITLE
Add description to "Log API Activity" & "Depend only on Trusted Code …

### DIFF
--- a/docs/api-security/06-CloudAPISecurity.md
+++ b/docs/api-security/06-CloudAPISecurity.md
@@ -36,8 +36,8 @@ Cloud API designers/developers **MUST** ensure the implementation achieves all o
 |   ▢   | Require robust authentication and authorisation     | OAuth2, SSO with OpenId Connect, request-level authorisation. |
 |   ▢   | Validate all incoming requests                      | *All* content of *all* incoming messages **MUST** be validated by the API implementation and/or its supporting infrastructure |
 |   ▢   | Throttle API requests and establish quotas          | Limit request rates to all endpoints that have the potential to consume or commit substantial human, compute or data resources |
-|   ▢   | Log API activity                                    |  |
-|   ▢   | Depend only on trusted code libraries / packages    |  |
+|   ▢   | Log API activity                                    |  |Log all sensitive security operations, which includes but not limited to: failed authentication/authorisation attempts, data validation errors, and sensitive business operations.
+|   ▢   | Depend only on trusted code libraries / packages    |  |Ensure third-party dependencies are regularly checked for known vulnerabilities, ideally in an automated manner within the CI/CD pipeline.  
 |   ▢   | Implement a zero-trust model                        | Do not allow session-based authentication eg. cookies           |
 |   ▢   | Filter traffic traversing public networks           | WAFs and API gateways to control requests arriving on Internet routes   |
 |   ▢   | Specific identity and access management             | Set specific policies / permissions that control access to sensitive resources like credentials, keys, configuration etc. |


### PR DESCRIPTION
…Libraries"

Missing descriptions added for Cloud Security API Controls.