### PR TITLE
add HL7 to first mentions of FHIR

### DIFF
--- a/docs/101-Glossaryofacronyms.md
+++ b/docs/101-Glossaryofacronyms.md
@@ -24,7 +24,7 @@ Content is draft and in review – this content may change until review is compl
 | ECDHE   | Elliptic Curve DHE                                 |
 | FAPI    | Financial-grade API                                |
 | FIDO    | See *U2F*                                          |
-| FHIR | Fast Healthcare Interoperability Resources - a standard describing data formats and elements and *API* for digital exchange of health information |
+| FHIR | Fast Healthcare Interoperability Resources - an HL7 standard describing data formats and elements and *API* for digital exchange of health information |
 | HATEOAS | Hypermedia As The Engine Of Application State      |
 | HEART   | [Health Relationship Trust](https://openid.net/wg/heart/) |
 | HPP     | HTTP Parameter Pollution                           |

--- a/docs/fhir-api-standard/Principles and Guidelines/01-Principles.md
+++ b/docs/fhir-api-standard/Principles and Guidelines/01-Principles.md
@@ -11,9 +11,9 @@ Content is draft and in review – this content may change until review is compl
 For information about how to contribute please see the [collaboration guidelines](/community/introduction).
 :::
 
-This section contains **RECOMMENDED** principles (this page) and guidelines (other pages) for all designers and implementers of Aotearoa New Zealand FHIR-based APIs.
+This section contains **RECOMMENDED** principles (this page) and guidelines (other pages) for all designers and implementers of Aotearoa New Zealand HL7 FHIR-based APIs.
 
-### Design principles for FHIR APIs
+### Design principles for HL7 FHIR APIs
 
 We encourage all designers and developers to strive for these principles to create quality FHIR-based APIs.
 

--- a/docs/fhir-api-standard/index.md
+++ b/docs/fhir-api-standard/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Part D: FHIR API Design and Development Standards"
+title: "Part D: HL7 FHIR API Design and Development Standards"
 sidebar_position: 5
 ---
 
@@ -7,7 +7,7 @@ sidebar_position: 5
 Content is draft and in review – this content may change until review is complete and formally published.
 :::
 
-Welcome to our API Design and Development Standards. This section is aimed at Fast Healthcare Interoperability Resources (FHIR) API Producers and Consumers.
+Welcome to our API Design and Development Standards. This section is aimed at API Producers and Consumers of HL7 Fast Health Care Resources (FHIR) APIs.
 
 This section is relevant to you if:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,9 @@ Part B contains the API security reference architecture and technical details fo
 
 Part C contains technical details for API development, including general API implementation standards for API developers and consuming application developers.
 
-[**Part D: FHIR API Standards**](/fhir-api-standard)
+[**Part D: HL7 FHIR API Standards**](/fhir-api-standard)
 
-Part D contains standards information and guidance for FHIR APIs
+Part D contains standards information and guidance for HL7 FHIR APIs
 
 :::info
 


### PR DESCRIPTION
Have added HL7 to the first mentions on a page of FHIR on the introductory pages - added to the top level index.md, sec D title, and FHIR section, glossary etc. 

Don't think we should update all/most mentions of FHIR with HL7 as it reduces readability and the FHIR standard itself doesn't do that. 