### PR TITLE
Disabled trailing slash

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,7 +25,7 @@ module.exports = async function createConfig() {
 
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'throw',
-
+    trailingSlash: false,
     // Even if you don't use internalization, you can use this field to set useful
     // metadata like html lang. For example, if your site is Chinese, you may want
     // to replace "en" with "zh-Hans".


### PR DESCRIPTION
Issue https://github.com/tewhatuora/api-standards/issues/196 describes broken links - note that when directly accessing the page https://apistandards.digital.health.nz/fhir-api-standard/Standards/Overview a trailing slash is added by Github Pages, which is breaking the relative links. When using the SPA navigation on the side menu to navigate to the same page, there is no trailing slash added, and the relative links work